### PR TITLE
Fix typo

### DIFF
--- a/scripts/segmentation/train.py
+++ b/scripts/segmentation/train.py
@@ -26,7 +26,7 @@ def parse_args():
                         help='model name (default: fcn)')
     parser.add_argument('--backbone', type=str, default='resnet50',
                         help='backbone name (default: resnet50)')
-    parser.add_argument('--dataset', type=str, default='pascalaug',
+    parser.add_argument('--dataset', type=str, default='pascal_aug',
                         help='dataset name (default: pascal)')
     parser.add_argument('--workers', type=int, default=16,
                         metavar='N', help='dataloader threads')


### PR DESCRIPTION
As in .data module, the dataset name for VOCAugSegmentation is "pascal_aug", not "pascalaug"

```python
datasets = {
    'ade20k': ADE20KSegmentation,
    'pascal_voc': VOCSegmentation,
    'pascal_aug': VOCAugSegmentation,
    'coco' : COCOSegmentation,
    'citys' : CitySegmentation,
}
```