### PR TITLE
Fix bug: mask can not be used to create filename

### DIFF
--- a/scripts/segmentation/test.py
+++ b/scripts/segmentation/test.py
@@ -65,13 +65,19 @@ def test(args):
             pixAcc, mIoU = metric.get()
             tbar.set_description( 'pixAcc: %.4f, mIoU: %.4f' % (pixAcc, mIoU))
         else:
-            im_paths = dsts
+            idxs = range(i * len(data), (i + 1) * len(data))
+            file_names = []
+            for idx in idxs:
+                img_id = testset.ids[idx]
+                img_metadata = testset.coco.loadImgs(img_id)[0]
+                file_name = img_metadata['file_name']
+                file_names.append(file_name)
             predicts = evaluator.parallel_forward(data)
-            for predict, impath in zip(predicts, im_paths):
+            for predict, file_name in zip(predicts, file_names):
                 predict = mx.nd.squeeze(mx.nd.argmax(predict[0], 1)).asnumpy() + \
                     testset.pred_offset
                 mask = get_color_pallete(predict, args.dataset)
-                outname = os.path.splitext(impath)[0] + '.png'
+                outname = os.path.splitext(file_name)[0] + '.png'
                 mask.save(os.path.join(outdir, outname))
 
 if __name__ == "__main__":


### PR DESCRIPTION
As defined in gluon.data,  looping through segmentation dataset return a set of (image, mask).
```python
    def __getitem__(self, index):
        img = Image.open(self.images[index]).convert('RGB')
        target = self._load_mat(self.masks[index])
        # synchrosized transform
        if self.mode == 'train':
            img, target = self._sync_transform(img, target)
        elif self.mode == 'val':
            img, target = self._val_sync_transform(img, target)
        else:
            raise RuntimeError('unknown mode for dataloader: {}'.format(self.mode))
        # general resize, normalize and toTensor
        if self.transform is not None:
            img = self.transform(img)
        return img, target
```
The mask is not string type, so we can't used it to create filename.
Instead of that, file_names are taken directly from testset using coco API